### PR TITLE
Added caseOption option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@ If you have remapped any of the `f`/`F`/`t`/`T`/`;`/`,` keys you can still use t
 `let g:ExtendedFTUseDefaults = 0`
 
 And then remapping the desired keys to the `<plug>` mappings in your .vimrc (see the bottom of the file vim-extended-ft.vim for an example).
+
+To force enable or disable smartcase matching, use this option in your .vimrc:
+
+`let g:ExtendedFT_caseOption = `
+
+Possible values:
+
+* \c - Forces `ignorecase`
+* \C - Forces `noignorecase`

--- a/plugin/extended-ft.vim
+++ b/plugin/extended-ft.vim
@@ -50,7 +50,12 @@ function! s:Search(count, char, dir, type)
 endfunction
 
 function! s:RunSearch(count, searchStr, dir, type)
-    let caseOption = (a:searchStr =~# '\v\u') ? '\C' : '\c'
+    if !exists('g:ExtendedFT_caseOption')
+        let caseOption = (a:searchStr =~# '\v\u') ? '\C' : '\c'
+    else
+        let caseOption = g:ExtendedFT_caseOption
+    endif
+
     let options = (a:dir ==# 'f') ? 'W' : 'Wb'
 
     let pattern = caseOption . a:searchStr
@@ -65,7 +70,7 @@ function! s:RunSearch(count, searchStr, dir, type)
         let pattern = pattern . '\zs'
     endif
 
-    let cnt = a:count > 0 ? a:count : 1 
+    let cnt = a:count > 0 ? a:count : 1
 
     for i in range(cnt)
         let lineNo = search('\V' . pattern, options . 'n')


### PR DESCRIPTION
New variable `let g:ExtendedFT_caseOption` takes values of `\c` or `\C`
to  force enable/disable smart case respectively.
